### PR TITLE
Fix less percentage

### DIFF
--- a/tldr
+++ b/tldr
@@ -333,7 +333,7 @@ Display_tldr(){
 	done <"$1"
 	[[ $TLDR_LESS = 0 ]] && 
 		trap 'cat <<<"$stdout"' EXIT ||
-		trap 'less -Gg -~RXQFP"%pB\% tldr $I$page$XI - browse up/down, press Q to exit" <<<"$stdout"' EXIT
+		trap 'less +Gg -~RXQFP"%pB\% tldr $I$page$XI - browse up/down, press Q to exit" <<<"$stdout"' EXIT
 }
 
 # $1: exit code; Uses: platform index


### PR DESCRIPTION
Found it!
Fix #10 

The problem is that less can't say what percent into the file you are until it knows how long the file is, and it doesn't read to the end of the file by default when reading from a pipe. 
If a command line option begins with `+`, the remainder of that option is taken to be an initial command to less.
`+Gg` command forces less to read to the end and back to the beginning of the file **FIRST**, before building the statusbar.

Thanks to [https://stackoverflow.com/questions/1049350/unable-to-make-less-to-indicate-location-in-percentage](url)